### PR TITLE
fixing SASL encryption bug when password forces line to wrap

### DIFF
--- a/src/main/java/com/couchbase/client/core/endpoint/config/ConfigHandler.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/config/ConfigHandler.java
@@ -52,6 +52,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.base64.Base64;
+import io.netty.handler.codec.base64.Base64Dialect;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
@@ -165,7 +166,7 @@ public class ConfigHandler extends AbstractGenericHandler<HttpObject, HttpReques
 
         ByteBuf raw = ctx.alloc().buffer(user.length() + pw.length() + 1);
         raw.writeBytes((user + ":" + pw).getBytes(CHARSET));
-        ByteBuf encoded = Base64.encode(raw);
+        ByteBuf encoded = Base64.encode(raw, false, Base64Dialect.STANDARD);
         request.headers().add(HttpHeaders.Names.AUTHORIZATION, "Basic " + encoded.toString(CHARSET));
         encoded.release();
         raw.release();


### PR DESCRIPTION
There is a bug where if the SASL password is too long, the base64 encoder puts new lines into the header before sending to couchbase. This causes errors in validation.