### PR TITLE
Utilize generic X509 PKIX TrustManager

### DIFF
--- a/src/main/java/com/couchbase/client/core/endpoint/SSLEngineFactory.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/SSLEngineFactory.java
@@ -66,8 +66,8 @@ public class SSLEngineFactory {
                 ks.load(new FileInputStream(ksFile), password);
             }
 
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("X509");
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance("X509");
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             kmf.init(ks, password);
             tmf.init(ks);
 

--- a/src/main/java/com/couchbase/client/core/endpoint/SSLEngineFactory.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/SSLEngineFactory.java
@@ -66,8 +66,8 @@ public class SSLEngineFactory {
                 ks.load(new FileInputStream(ksFile), password);
             }
 
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("X509");
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("X509");
             kmf.init(ks, password);
             tmf.init(ks);
 

--- a/src/main/java/com/couchbase/client/core/endpoint/SSLEngineFactory.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/SSLEngineFactory.java
@@ -65,9 +65,9 @@ public class SSLEngineFactory {
                 }
                 ks.load(new FileInputStream(ksFile), password);
             }
-
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            String defaultAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(defaultAlgorithm);
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(defaultAlgorithm);
             kmf.init(ks, password);
             tmf.init(ks);
 


### PR DESCRIPTION
Current Java Core SSL implementation relies on Oracle's SunX509 algorithm. This prevents use of smart client in certain application deployment servers (i.e. IBM WAS uses IBM JRE). I propose using provider agnostic algorithm; since all JREs must support standard PKIX algorithm, smart client could safely utilize underlying PKIX algorithm.