### PR TITLE
Fix Scram Sha Authentication

### DIFF
--- a/src/main/java/com/couchbase/client/core/endpoint/kv/KeyValueAuthHandler.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/kv/KeyValueAuthHandler.java
@@ -237,6 +237,10 @@ public class KeyValueAuthHandler
         msg.content().readBytes(response);
         byte[] evaluatedBytes = saslClient.evaluateChallenge(response);
 
+        
+        // This condition is needed for evaluate SASL Step Response. 
+        // After saslClient.evaluateChallenge(), if SaslException is not thrown and 
+        // if ShaSaslClient.serverFinalMessage is not null, authentication is completed
         if (saslClient.isComplete()) {
             checkIsAuthed(msg);
             return;

--- a/src/main/java/com/couchbase/client/core/endpoint/kv/KeyValueAuthHandler.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/kv/KeyValueAuthHandler.java
@@ -174,7 +174,11 @@ public class KeyValueAuthHandler
     protected void channelRead0(ChannelHandlerContext ctx, FullBinaryMemcacheResponse msg) throws Exception {
         if (msg.getOpcode() == SASL_LIST_MECHS_OPCODE) {
             handleListMechsResponse(ctx, msg);
-        } else if (msg.getOpcode() == SASL_AUTH_OPCODE || msg.getOpcode() == SASL_STEP_OPCODE) {
+        }
+        // It is necessary to call handleAuthResponse() for evaluate Auth Response and
+        // Step Response returned by the server. If this step is not done, the client
+        // doesn't authenticate the server.
+        else if (msg.getOpcode() == SASL_AUTH_OPCODE || msg.getOpcode() == SASL_STEP_OPCODE) {
             handleAuthResponse(ctx, msg);
         }
     }
@@ -287,7 +291,8 @@ public class KeyValueAuthHandler
     }
 
     /**
-     * Once authentication is completed, check the response and react appropriately to the upper layers.
+     * Once authentication is completed, check the response and react appropriately
+     * to the upper layers.
      *
      * @param msg the incoming message to investigate.
      */


### PR DESCRIPTION
SASL Authentication mechanism provides by Couchbase Java client is not safe.  The value returned by Couchbase Server for SASL Step Response is not evaluated.

See https://tools.ietf.org/html/rfc5802#page-9
SASL Step exchange:

  The server verifies the nonce and the proof, verifies that the authorization identity (if supplied by the client in the first message) is authorized to act as the authentication identity, and, finally, it responds with a "server-final-message", concluding the authentication exchange.

   The client then authenticates the server by computing the ServerSignature and comparing it to the value sent by the server.  If the two are different, the client MUST consider the authentication exchange to be unsuccessful, and it might have to drop the connection.