### PR TITLE
fix: allow maxEndpoints to be set to 0

### DIFF
--- a/src/main/java/com/couchbase/client/core/env/AbstractServiceConfig.java
+++ b/src/main/java/com/couchbase/client/core/env/AbstractServiceConfig.java
@@ -68,9 +68,6 @@ public abstract class AbstractServiceConfig {
         if (minEndpoints < 0 || maxEndpoints < 0) {
             throw new IllegalArgumentException("The minEndpoints and maxEndpoints must not be negative");
         }
-        if (maxEndpoints == 0) {
-            throw new IllegalArgumentException("The maxEndpoints must be greater than 0");
-        }
         if (maxEndpoints < minEndpoints) {
             throw new IllegalArgumentException("The maxEndpoints must not be smaller than mindEndpoints");
         }


### PR DESCRIPTION
From https://docs.couchbase.com/java-sdk/2.6/client-settings.html

> If no view load is expected, setting this value explicitly to 0 can avoid one socket to 8092 per node.
> If no query load is expected, setting this value explicitly to 0 can avoid one socket to 8093 per node.

But setting `maxEndpoints` to 0 currently throws an `IllegalArgumentException`.

Or should the service be disabled somewhere else?