### PR TITLE
Bump jackson databind version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <opentracing.version>0.31.0</opentracing.version>
         <netty.version>4.0.56.Final</netty.version>
         <disruptor.version>3.3.10</disruptor.version>
-        <jackson.version>2.9.9.1</jackson.version>
+        <jackson.version>2.9.9.2</jackson.version>
         <snappy.version>0.4</snappy.version>
         <latency-utils.version>2.0.3</latency-utils.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Jackson databind 2.9.9.2 contains additional security fixes.

See https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x#L69