### PR TITLE
Update KeyValueServiceConfig.java

### DIFF
--- a/src/main/java/com/couchbase/client/core/env/KeyValueServiceConfig.java
+++ b/src/main/java/com/couchbase/client/core/env/KeyValueServiceConfig.java
@@ -53,6 +53,10 @@ public final class KeyValueServiceConfig extends AbstractServiceConfig {
         return new KeyValueServiceConfig(endpoints, endpoints);
     }
 
+    public static KeyValueServiceConfig create(final int endpointLow, final int endpointHigh) {
+        return new KeyValueServiceConfig(endpointLow, endpointHigh);
+    }
+    
     @Override
     public String toString() {
         return "KeyValueServiceConfig{" +


### PR DESCRIPTION
Currently the SDK has only private access to the KeyValueServiceConfig and does not allow users to create a range. Override the function to allow a single value or a range.