### PR TITLE
Add OpenSSL support to couchbase client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,16 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <native.folder>${project.build.directory}/native</native.folder>
-        <native.original>libnetty_transport_native_epoll_x86_64.so</native.original>
-        <native.renamed>libcom_couchbase_client_deps_netty_transport_native_epoll_x86_64.so</native.renamed>
+        <nativetcantive.original>libnetty_tcnative.so</nativetcantive.original>
+        <nativetcantive.renamed>libcom_couchbase_client_deps_netty_tcnative.so</nativetcantive.renamed>
+        <nativetcantiveosx.original>libnetty_tcnative.jnilib</nativetcantiveosx.original>
+        <nativetcantiveosx.renamed>libcom_couchbase_client_deps_netty_tcnative.jnilib</nativetcantiveosx.renamed>
+        <nativeepoll.original>libnetty_transport_native_epoll_x86_64.so</nativeepoll.original>
+        <nativeepoll.renamed>libcom_couchbase_client_deps_netty_transport_native_epoll_x86_64.so</nativeepoll.renamed>
         <rxjava.version>1.3.8</rxjava.version>
         <opentracing.version>0.31.0</opentracing.version>
         <netty.version>4.0.56.Final</netty.version>
+        <tcnative.version>2.0.10.Final</tcnative.version>
         <disruptor.version>3.4.2</disruptor.version>
         <jackson.version>2.9.9.3</jackson.version>
         <snappy.version>0.4</snappy.version>
@@ -113,6 +118,13 @@
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
             <version>${opentracing.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${tcnative.version}</version>
+            <classifier>${os.detected.classifier}</classifier>
         </dependency>
 
         <!-- Shaded, Required Dependencies -->
@@ -281,7 +293,51 @@
                 <version>2.10</version>
                 <executions>
                     <execution>
-                        <id>unpack</id>
+                        <id>unpackboringssl</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.netty</groupId>
+                                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                                    <classifier>${os.detected.classifier}</classifier>
+                                    <outputDirectory>${native.folder}</outputDirectory>
+                                    <includes>META-INF/native/libnetty_tcnative.so</includes>
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>META-INF/native/libnetty_tcnative.so</includes>
+                            <outputDirectory>${native.folder}</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpackboringssl_osx</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.netty</groupId>
+                                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                                    <classifier>${os.detected.classifier}</classifier>
+                                    <outputDirectory>${native.folder}</outputDirectory>
+                                    <includes>META-INF/native/libnetty_tcnative.jnilib</includes>
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>META-INF/native/libnetty_tcnative.jnilib</includes>
+                            <outputDirectory>${native.folder}</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpackepoll</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
@@ -314,7 +370,9 @@
                         <filter>
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/native/${native.original}</exclude>
+                                <exclude>META-INF/native/${nativeepoll.original}</exclude>
+                                <exclude>META-INF/native/${nativetcantive.original}</exclude>
+                                <exclude>META-INF/native/${nativetcantiveosx.original}</exclude>
                             </excludes>
                         </filter>
                     </filters>
@@ -322,10 +380,17 @@
                         <!-- Netty Native: with the unpacked .so (see unpack config), rename
                              it so it has the shaded namespace -->
                         <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                            <file>${native.folder}/META-INF/native/${native.original}</file>
-                            <resource>META-INF/native/${native.renamed}</resource>
+                            <file>${native.folder}/META-INF/native/${nativeepoll.original}</file>
+                            <resource>META-INF/native/${nativeepoll.renamed}</resource>
                         </transformer>
-
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                            <file>${native.folder}/META-INF/native/${nativetcantive.original}</file>
+                            <resource>META-INF/native/${nativetcantive.renamed}</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                            <file>${native.folder}/META-INF/native/${nativetcantiveosx.original}</file>
+                            <resource>META-INF/native/${nativetcantiveosx.renamed}</resource>
+                        </transformer>
                     </transformers>
                     <artifactSet>
                         <excludes>
@@ -483,6 +548,13 @@
                 </executions>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </extension>
+        </extensions>
 
         <resources>
             <resource>

--- a/src/main/java/com/couchbase/client/core/env/DefaultCoreEnvironment.java
+++ b/src/main/java/com/couchbase/client/core/env/DefaultCoreEnvironment.java
@@ -78,6 +78,7 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
     private static final CouchbaseLogger LOGGER = CouchbaseLoggerFactory.getInstance(CoreEnvironment.class);
 
     public static final boolean SSL_ENABLED = false;
+    public static final boolean OPENSSL_ENABLED = false;
     public static final String SSL_KEYSTORE_FILE = null;
     public static final String SSL_TRUSTSTORE_FILE = null;
     public static final String SSL_KEYSTORE_PASSWORD = null;
@@ -289,6 +290,7 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
 
     private final boolean orphanResponseReportingEnabled;
     private final OrphanResponseReporter orphanResponseReporter;
+    private final boolean openSslEnabled;
 
     protected DefaultCoreEnvironment(final Builder builder) {
         boolean emitEnvWarnMessage = false;
@@ -299,6 +301,7 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
         }
 
         sslEnabled = booleanPropertyOr("sslEnabled", builder.sslEnabled);
+        openSslEnabled = booleanPropertyOr("openSslEnabled", builder.openSslEnabled);
         sslKeystoreFile = stringPropertyOr("sslKeystoreFile", builder.sslKeystoreFile);
         sslTruststoreFile = stringPropertyOr("sslTruststoreFile", builder.sslTruststoreFile);
         sslKeystorePassword = stringPropertyOr("sslKeystorePassword", builder.sslKeystorePassword);
@@ -755,6 +758,11 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
     }
 
     @Override
+    public boolean openSslEnabled() {
+        return openSslEnabled;
+    }
+
+    @Override
     public String sslKeystoreFile() {
         return sslKeystoreFile;
     }
@@ -1124,6 +1132,7 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
     public static class Builder<SELF extends Builder<SELF>> {
 
         private boolean sslEnabled = SSL_ENABLED;
+        private boolean openSslEnabled = OPENSSL_ENABLED;
         private String sslKeystoreFile = SSL_KEYSTORE_FILE;
         private String sslTruststoreFile = SSL_TRUSTSTORE_FILE;
         private String sslKeystorePassword = SSL_KEYSTORE_PASSWORD;
@@ -1219,6 +1228,15 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
          */
         public SELF sslEnabled(final boolean sslEnabled) {
             this.sslEnabled = sslEnabled;
+            return self();
+        }
+
+        /**
+         * Set if we want to use the OpenSSL Client Library instead of Java SDK
+         * Set only if sslEnabled = true.
+         */
+        public SELF openSslEnabled(final boolean openSslEnabled) {
+            this.openSslEnabled = openSslEnabled;
             return self();
         }
 
@@ -2058,6 +2076,7 @@ public class DefaultCoreEnvironment implements CoreEnvironment {
      */
     protected StringBuilder dumpParameters(StringBuilder sb) {
         sb.append("sslEnabled=").append(sslEnabled);
+        sb.append(", openSslEnabled=").append(openSslEnabled);
         sb.append(", sslKeystoreFile='").append(sslKeystoreFile).append('\'');
         sb.append(", sslTruststoreFile='").append(sslTruststoreFile).append('\'');
         sb.append(", sslKeystorePassword=").append(sslKeystorePassword != null && !sslKeystorePassword.isEmpty());

--- a/src/main/java/com/couchbase/client/core/env/SecureEnvironment.java
+++ b/src/main/java/com/couchbase/client/core/env/SecureEnvironment.java
@@ -105,4 +105,10 @@ public interface SecureEnvironment {
      */
     KeyStore sslTruststore();
 
+    /**
+     * Whether to use openSSL stack.
+     * @return
+     */
+    boolean openSslEnabled();
+
 }

--- a/src/test/java/com/couchbase/client/core/endpoint/SSLEngineFactoryTest.java
+++ b/src/test/java/com/couchbase/client/core/endpoint/SSLEngineFactoryTest.java
@@ -16,6 +16,11 @@
 package com.couchbase.client.core.endpoint;
 
 import com.couchbase.client.core.env.CoreEnvironment;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.OpenSslEngine;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Test;
 
 import javax.net.ssl.SSLEngine;
@@ -23,6 +28,7 @@ import javax.net.ssl.SSLEngine;
 import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,5 +79,66 @@ public class SSLEngineFactoryTest {
 
     private String getKeystorePath() throws URISyntaxException {
         return getClass().getResource("keystore.jks").toURI().getPath();
+    }
+
+    @Test
+    public void testOpenSSLTLS() {
+        if(OpenSsl.isAvailable()) {
+            CoreEnvironment environment = mock(CoreEnvironment.class);
+            when(environment.openSslEnabled()).thenReturn(true);
+            when(environment.sslKeystoreFile()).thenReturn(this.getClass().getResource("keystore.jks").getPath());
+            when(environment.sslKeystorePassword()).thenReturn("keystore");
+            SSLEngineFactory factory = new SSLEngineFactory(environment, "TLS");
+            SSLEngine engine = factory.get();
+
+            assertTrue(engine instanceof OpenSslEngine);
+            Set<String> enabledProtocols = new HashSet<String>(Arrays.asList(engine.getEnabledProtocols()));
+            assertEquals(enabledProtocols.size(), 5L);
+
+            //https://github.com/netty/netty/issues/7935
+            //There is no way to disable SSLv2, SSLv2Hello on the netty 4.0.56
+            assertTrue(enabledProtocols.contains("SSLv2Hello"));
+            assertTrue(enabledProtocols.contains("SSLv2"));
+            assertTrue(enabledProtocols.contains("TLSv1"));
+            assertTrue(enabledProtocols.contains("TLSv1.1"));
+            assertTrue(enabledProtocols.contains("TLSv1.2"));
+            assertTrue(engine.getUseClientMode());
+        }
+    }
+
+    @Test
+    public void testOpenSSLTLSv_1_2() {
+        if(OpenSsl.isAvailable()) {
+            CoreEnvironment environment = mock(CoreEnvironment.class);
+            when(environment.openSslEnabled()).thenReturn(true);
+            when(environment.sslKeystoreFile()).thenReturn(this.getClass().getResource("keystore.jks").getPath());
+            when(environment.sslKeystorePassword()).thenReturn("keystore");
+            SSLEngineFactory factory = new SSLEngineFactory(environment, "TLSv1.2");
+            SSLEngine engine = factory.get();
+            assertTrue(engine instanceof OpenSslEngine);
+
+            //https://github.com/netty/netty/issues/7935
+            //There is no way to disable SSLv2, SSLv2Hello on the netty 4.0.56
+
+            Set<String> enabledProtocols = new HashSet<String>(Arrays.asList(engine.getEnabledProtocols()));
+            assertEquals(enabledProtocols.size(), 3L);
+            assertTrue(enabledProtocols.contains("SSLv2Hello"));
+            assertTrue(enabledProtocols.contains("TLSv1.2"));
+            assertTrue(enabledProtocols.contains("SSLv2"));
+            assertTrue(engine.getUseClientMode());
+        }
+    }
+
+    @Test(expected = SSLException.class)
+    public void shouldFailWithSSLOverrideWithOpenSSL() {
+        if(OpenSsl.isAvailable()) {
+            CoreEnvironment environment = mock(CoreEnvironment.class);
+            when(environment.openSslEnabled()).thenReturn(true);
+            when(environment.sslKeystoreFile()).thenReturn(this.getClass().getResource("keystore.jks").getPath());
+            when(environment.sslKeystorePassword()).thenReturn("keystore");
+
+            SSLEngineFactory factory = new SSLEngineFactory(environment, "SSLv3");
+            factory.get();
+        }
     }
 }


### PR DESCRIPTION
Motivation
----------
Couchbase Core IO uses netty4 as base.
Netty4 supports OpenSSL. OpenSSL provides better performance than the native JDK implementation.
This commit tries to enable openSSL by using the boring ssl implementation of tc native available for Netty4.

By default openSSL is disabled in the couchbase client SSL factory. The feature can be enabled by explicitly
overriding the property openSslEnabled in the DefaultEnvironment builder.

Limitation: The current couch base SSLEngineFactory class allows ssl protocols to be explicitly configured using
the com.couchbase.sslProtocol property. This was introduced to configure TLS properties and also limit the use
of the protocols to TLS while disabling weaker protocols like SSL. Given that netty version is 4.0.56.Final, we
cannot enforce the protocols to only TLS. This bug is documented https://github.com/netty/netty/issues/7935 and
has been fixed in subsequent versions. So when the openSSL implementation is enabled, it is not possible to disable
SSL protocols explicitly.

Laxman. Prabhu
Senior Software Engineer 
Data Infrastructure at Linkedin.