### PR TITLE
Bugfix/honour host http header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>com.couchbase.client</groupId>
     <artifactId>core-io</artifactId>
-    <version>1.7.18</version>
+    <version>1.7.19-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Couchbase JVM Core IO</name>

--- a/src/main/java/com/couchbase/client/core/endpoint/AbstractGenericHandler.java
+++ b/src/main/java/com/couchbase/client/core/endpoint/AbstractGenericHandler.java
@@ -952,7 +952,7 @@ public abstract class AbstractGenericHandler<RESPONSE, ENCODED, REQUEST extends 
             SocketAddress addr = ctx.channel().remoteAddress();
             if (addr instanceof InetSocketAddress) {
                 InetSocketAddress inetAddr = (InetSocketAddress) addr;
-                remoteHttpHost = inetAddr.getAddress().getHostAddress() + ":" + inetAddr.getPort();
+                remoteHttpHost = inetAddr.getAddress().getHostName() + ":" + inetAddr.getPort();
             } else {
                 remoteHttpHost = addr.toString();
             }


### PR DESCRIPTION
`AbstractGenericHandler` class wrongly uses remote host IP address instead of remote host name to populate the HTTP Host header.

Earlier in the class, comments around similar code mentions the IP address is used explicitly to avoid unnecessary name resolution but this doesn't apply to HTTP headers.

This makes edge routers (e.g. [traefik](https://doc.traefik.io/traefik/v2.3/)) fail to forward requests to the correct localtion.