### PR TITLE
Updating Netty to 4.1.89.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <native-kqueue.renamed>libcom_couchbase_client_deps_netty_transport_native_kqueue_x86_64.jnilib</native-kqueue.renamed>
         <rxjava.version>1.3.8</rxjava.version>
         <opentracing.version>0.31.0</opentracing.version>
-        <netty.version>4.1.84.Final</netty.version>
+        <netty.version>4.1.89.Final</netty.version>
         <disruptor.version>3.4.4</disruptor.version>
         <jackson.version>2.14.0</jackson.version>
         <snappy.version>0.4</snappy.version>


### PR DESCRIPTION
A fix for https://nvd.nist.gov/vuln/detail/CVE-2022-41915 and https://nvd.nist.gov/vuln/detail/CVE-2022-41881
